### PR TITLE
adds authenticate middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,16 @@
 const express = require('express');
+
+const { authenticate } = require('./middleware/authenticate');
+
 const app = express();
+
 
 app.get('/chimeras', (req, res) => {
   res.send({ msg: 'We are Chimeras!!! 🔥'})
+});
+
+app.get('/authenticateTest', authenticate, (req, res) => {
+  res.send({user: req.user, token: req.token });
 });
 
 const PORT = 5000;

--- a/middleware/authenticate.js
+++ b/middleware/authenticate.js
@@ -1,0 +1,18 @@
+
+
+const authenticate = (req, res, next) => {
+    // Check the header for a token value.
+    // if there's a token value, check the DB to see if it's still valid.
+    const token = req.header('x-auth');
+    if (token) {
+        const user = 'test-user';
+        req.user = user;
+        req.token = token;
+        next();
+    } 
+    // If there is no x-auth token, send authentication error (401)
+    res.status(401).send();
+    
+}
+
+module.exports = { authenticate };


### PR DESCRIPTION
Sets up basic authentication - To test, make a get request to /authenticateTest and add an 'x-auth' key with any random value to the header.
Not having an x-auth will return an unauthorized (401) error.